### PR TITLE
Upgraded to variable pixels per segment/decimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can then initialise the display with the following line that includes the nu
 You can also initialise the display with custom pixels per segment and pixel per decimal point
 
 	#define PIXELS_DIGITS       5   // Number of digits
-	#define PIXELS_PER_SEGMENT  4   // Pixels per segment - If you want more than 10 pixels per segment, modify the Neo7Segment_Var.cpp
+	#define PIXELS_PER_SEGMENT  4   // Pixels per segment - If you want more than 10 pixels per segment, modify the Neo7Segment.cpp
 	#define PIXELS_PER_POINT    1   // Pixels per decimal point - CANNOT be higher than PIXELS_PER_SEGMENT
 	#define PIXELS_PIN          4   // Pin number
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ You can then initialise the display with the following line that includes the nu
 
     Neo7Segment disp( 5, 4 );
 
+You can also initialise the display with custom pixels per segment and pixel per decimal point
+
+	#define PIXELS_DIGITS       5   // Number of digits
+	#define PIXELS_PER_SEGMENT  4   // Pixels per segment - If you want more than 10 pixels per segment, modify the Neo7Segment_Var.cpp
+	#define PIXELS_PER_POINT    1   // Pixels per decimal point - CANNOT be higher than PIXELS_PER_SEGMENT
+	#define PIXELS_PIN          4   // Pin number
+
+	// Initalise the display with 5 Neo7Segment boards, 4 LEDs per segment, 1 decimal point LED, connected to GPIO 4
+	Neo7Segment disp(PIXELS_DIGITS, PIXELS_PER_SEGMENT, PIXELS_PER_POINT, PIXELS_PIN);
+
 You then start the display with the bebin method, passing the brightness:
 
     disp.Begin(20);

--- a/examples/Neo7Segment_Counter/Neo7Segment_Counter.ino
+++ b/examples/Neo7Segment_Counter/Neo7Segment_Counter.ino
@@ -1,0 +1,225 @@
+//Displays all digits with the same number counting from 0 to 9. Odd numbers have decimal point ON, others OFF.
+//Push button on pin 5 to control color changing
+#include <Neo7Segment.h>
+
+#define PIXELS_DIGITS       5   // Number of digits
+#define PIXELS_PER_SEGMENT  4   // If you want more than 10 pixels per segment, modify the Neo7Segment_Var.cpp
+#define PIXELS_PER_POINT    1   // CANNOT be higher than PIXELS_PER_SEGMENT
+#define PIXELS_PIN          4   // Pin number
+
+// Initalise the display with 5 Neo7Segment boards, 4 LEDs per segment, 1 decimal point LED, connected to GPIO 4
+Neo7Segment disp(PIXELS_DIGITS, PIXELS_PER_SEGMENT, PIXELS_PER_POINT, PIXELS_PIN);
+
+int loopIndex               = 0;
+byte rainbowIndex           = 0;
+unsigned long nextRainbow   = 0;
+int displayFeature          = 0;
+long nextCount              = millis();
+
+//Button pin define
+#define buttonPin           5
+
+bool changeColor            = false;
+bool buttonActive           = false;
+int digitDisplay            = 0;
+
+String text                 = "";
+
+void setup()
+{
+  Serial.begin(9600);
+  delay(1000);
+
+  pinMode(buttonPin, INPUT);
+
+  // Start the display with a brightness value of 20
+  disp.Begin(20);
+
+  // Set the initial display feature to show as 0
+  displayFeature = 0;
+}
+
+void loop()
+{
+  // Wait until the display is initialised before we try to show anything
+  if ( !disp.IsReady() )
+    return;
+
+  readButtonPush();
+
+  if ( millis() > nextCount )
+  {
+    digitDisplay += 1;
+    nextCount = millis() + 1000;
+  }
+
+  if (digitDisplay > 9)
+    digitDisplay = 0;
+
+  String dot = ( ( digitDisplay%2 ) == 0 ) ? "." : "";
+  String digit = String( digitDisplay );
+
+  text = "";
+  for ( int i = 0; i < PIXELS_DIGITS; i++ )
+    text = text + digit + dot;
+
+  // Switch sequence when pressing on button
+  if ( changeColor )
+    displayFeature = (displayFeature + 1) % 13;
+
+  // Display stuff on the Neo7Segment displays
+  if (nextRainbow < millis() || changeColor)
+    colorChangingSequences();
+
+  changeColor = false;
+}
+
+void colorChangingSequences()
+{
+  switch(displayFeature)
+  {
+    case 0:
+      disp.DisplayTextColorCycle( text, rainbowIndex );
+      nextRainbow = millis() + 10;
+      rainbowIndex++;
+      break;
+
+    case 1:
+      disp.DisplayTextVerticalRainbow( text, disp.Color(255,0,0), disp.Color(0,0,255) );
+      nextRainbow = millis() + 10;
+      break;
+
+    case 2:
+        nextRainbow = millis() + 250;
+        rainbowIndex+=5;
+        loopIndex++;
+        if (loopIndex > 1)
+          loopIndex = 0;
+
+        disp.ForceUppercase( true );
+        disp.DisplayTextMarquee( text, loopIndex, disp.Wheel( rainbowIndex & 255 ) );
+
+      break;
+
+    case 3:
+      disp.ForceUppercase( false );
+      disp.DisplayTextVerticalRainbow( text, disp.Wheel( rainbowIndex & 255 ) , disp.Wheel( ( rainbowIndex + 50 ) & 255 ) );
+      nextRainbow = millis() + 10;
+      rainbowIndex--;
+      break;
+
+    case 4:
+      nextRainbow = millis() + 50;
+      rainbowIndex+=5;
+      loopIndex++;
+      if ( loopIndex > ( PIXELS_PER_SEGMENT-1 ) )
+        loopIndex = 0;
+
+      disp.DisplayTextChaser( text, loopIndex, disp.Wheel( rainbowIndex & 255 ) );
+
+      break;
+
+    case 5:
+      rainbowIndex++;
+
+      if (rainbowIndex % 5 == 0)
+      {
+        loopIndex++;
+        if (loopIndex >= disp.GetSpinAllLength())
+          loopIndex = 0;
+      }
+
+      disp.SetDigitSegments(0, disp.GetSpinAllAtIndex(loopIndex), disp.Color(0, 0, 50));
+      disp.SetDigitSegments(1, disp.GetSpinAllAtIndex(loopIndex), disp.Color(0, 0, 100));
+      disp.SetDigitSegments(2, disp.GetSpinAllAtIndex(loopIndex), disp.Color(0, 0, 150));
+      disp.SetDigitSegments(3, disp.GetSpinAllAtIndex(loopIndex), disp.Color(0, 0, 200));
+      disp.SetDigitSegments(4, disp.GetSpinAllAtIndex(loopIndex), disp.Color(0, 0, 250));
+
+      for (int i = 5; i<PIXELS_DIGITS; i++)
+        disp.SetDigit(i, "", disp.Color(0, 0, 0));
+
+      nextRainbow = millis() + 10;
+      break;
+
+    case 6:
+      if (rainbowIndex > (2*PIXELS_PER_SEGMENT*PIXELS_DIGITS))
+        rainbowIndex = 0;
+
+      disp.DisplayKnightRider(rainbowIndex, disp.Color(255,0,255));
+      nextRainbow = millis() + 10;
+      rainbowIndex++;
+      break;
+
+     case 7:
+      disp.ForceUppercase(false);
+      disp.DisplayTextHorizontalRainbow(text, disp.Wheel(rainbowIndex & 255) , disp.Wheel((rainbowIndex + 150) & 255));
+      nextRainbow = millis() + 50;
+      rainbowIndex--;
+      break;
+
+    case 8://
+      disp.DisplayBorderAnimation(rainbowIndex, disp.Color(0, 0, 250));
+      nextRainbow = millis() + 100;
+      rainbowIndex--;
+      break;
+
+    case 9:
+      disp.DisplayTime((digitDisplay*10+digitDisplay), (digitDisplay*10+digitDisplay), digitDisplay, disp.Color(255, 200, 0), disp.Color(0, 0, 255));
+      nextRainbow = millis() + 500;
+      break;
+
+    case 10:
+      disp.DisplayTextColorCycle(text, rainbowIndex);
+      nextRainbow = millis() + 10;
+      rainbowIndex++;
+      break;
+
+    case 11: // Same as case #5, but allows to send complete string and change each digit's color
+      uint32_t digitColors[PIXELS_DIGITS];
+	    digitColors[0] = disp.Color(255, 0, 0);
+	    digitColors[1] = disp.Color(127, 127, 0);
+	    digitColors[2] = disp.Color(0, 255, 0);
+	    digitColors[3] = disp.Color(0, 127, 127);
+	    digitColors[4] = disp.Color(0, 0, 255);
+
+      for (int i = 5; i<PIXELS_DIGITS; i++)
+        digitColors[i] = disp.Color(0, 0, 0);
+
+      disp.DisplayTextDigitColor(text, digitColors);
+      nextRainbow = millis() + 50;
+      rainbowIndex++;
+      break;
+
+    case 12: // Same as case #5, but allows to send string character (only first will be used) and change only one digit at a time
+      disp.SetDigit(0, text, disp.Color(0, 0, 255));
+      disp.SetDigit(1, text, disp.Color(0, 127, 127));
+      disp.SetDigit(2, text, disp.Color(0, 255, 0));
+      disp.SetDigit(3, text, disp.Color(127, 127, 0));
+      disp.SetDigit(4, text, disp.Color(255, 0, 0));
+
+      nextRainbow = millis() + 50;
+      rainbowIndex++;
+      break;
+
+    default:
+      displayFeature = 0;
+      break;
+  }
+}
+
+void readButtonPush()
+{
+  bool buttonPressed = !digitalRead(buttonPin);
+  if (buttonPressed)
+  {
+    if (!buttonActive)
+      buttonActive = true;
+  }
+  else
+  {
+    if (buttonActive)
+      changeColor = true;
+
+    buttonActive = false;
+  }
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Neo7Segment
-version=1.0.1
+version=2.0.3
 author=UnexpectedMaker
 maintainer=UnexpectedMaker
 sentence=A library to display numbers and letters on Neo7Segment displays.

--- a/src/Neo7Segment.cpp
+++ b/src/Neo7Segment.cpp
@@ -11,6 +11,7 @@
 #include <Adafruit_NeoPixel.h>
 
 //#define DEBUG
+#define USEDP
 
 // Array of segment based rainbow colour values
 uint32_t segmentRainbow[7][3] {
@@ -142,13 +143,17 @@ byte AnimEdgeRight[4] 	{
 Neo7Segment::Neo7Segment( uint8_t displayCount, uint8_t dPixels, uint8_t dpPixels, uint8_t dPin )
 {
 	//Count number of pixels per decimal point (Between 0 and number of segment pixels)
-	dispPixelDp = constrain(dpPixels, 0, constrain(dPixels, 1, PIXELS_PER_SEGMENT_MAX));
+	#ifdef USEDP
+		dispPixelDp = constrain(dpPixels, 0, constrain(dPixels, 1, PIXELS_PER_SEGMENT_MAX));
+	#else
+		dispPixelDp = 0;
+	#endif
 
 	//Count number of pixels per digit board (Between 1 and maximum pixels)
 	NUM_PIXELS_PER_BOARD = ( constrain( dPixels, 1, PIXELS_PER_SEGMENT_MAX )*7) + dispPixelDp;
 
 	//Detect that decimal poiunt is used or not
-	dispUseDP = dpPixels>0 ? true : false;
+	dispUseDP = dispPixelDp>0 ? true : false;
 
 	dispPixelSegment = dPixels;
 	dispCount = displayCount;
@@ -157,6 +162,31 @@ Neo7Segment::Neo7Segment( uint8_t displayCount, uint8_t dPixels, uint8_t dpPixel
 	pixels.updateType( NEO_GRB + NEO_KHZ800 );
   	pixels.updateLength( dispCount * NUM_PIXELS_PER_BOARD );
   	pixels.setPin(dispPin);
+	isReady = false;
+}
+
+Neo7Segment::Neo7Segment( uint8_t displayCount, uint8_t dPin )
+{
+	//Count number of pixels per decimal point (Between 0 and number of segment pixels)
+	#ifdef USEDP
+		dispPixelDp = 1;
+	#else
+		dispPixelDp = 0;
+	#endif
+
+	//Count number of pixels per digit board (Between 1 and maximum pixels)
+	NUM_PIXELS_PER_BOARD = 28 + dispPixelDp;
+
+	//Detect that decimal poiunt is used or not
+	dispUseDP = dispPixelDp>0 ? true : false;
+
+	dispPixelSegment = 4;
+	dispCount = displayCount;
+	dispPin = dPin;
+	pixels = Adafruit_NeoPixel ();
+	pixels.updateType( NEO_GRB + NEO_KHZ800 );
+	pixels.updateLength( dispCount * NUM_PIXELS_PER_BOARD );
+	pixels.setPin(dispPin);
 	isReady = false;
 }
 

--- a/src/Neo7Segment.cpp
+++ b/src/Neo7Segment.cpp
@@ -523,6 +523,7 @@ void Neo7Segment::DisplayTextMarquee( String text, uint8_t index, uint32_t color
 			}
 		}
 	}
+
 	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
 	pixels.show();
 }
@@ -565,6 +566,7 @@ void Neo7Segment::DisplayTextChaser( String text, uint8_t index, uint32_t color 
 			}
 		}
 	}
+
 	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
 	pixels.show();
 }
@@ -647,6 +649,7 @@ void Neo7Segment::DisplayTextColor( String text, uint32_t color )
 			}
 		}
 	}
+
 	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
 	pixels.show();
 }
@@ -683,6 +686,7 @@ void Neo7Segment::DisplayTextDigitColor( String text, uint32_t color[] )
 			}
 		}
 	}
+
 	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
 	pixels.show();
 }
@@ -812,6 +816,7 @@ void Neo7Segment::DisplayKnightRider( uint8_t index, uint32_t color )
 				pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), Color(0,0,0) );
 		}
 	}
+
 	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
 	pixels.show();
 }
@@ -949,6 +954,7 @@ void Neo7Segment::SetDigit( uint8_t digit, String text, uint32_t color )
 		}
 	}
 
+	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
 	pixels.show();
 }
 
@@ -974,6 +980,7 @@ void Neo7Segment::SetDigitSegments( uint8_t digit, byte bits, uint32_t color )
 			pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( digit * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
 	}
 
+	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
 	pixels.show();
 }
 

--- a/src/Neo7Segment.cpp
+++ b/src/Neo7Segment.cpp
@@ -1,5 +1,6 @@
 // ---------------------------------------------------------------------------
 // Created by Seon Rozenblum - seon@unexpectedmaker.com
+// Modified by Jean Gauthier P.Eng. - SupremeSports (2019-01-06)
 // Copyright 2016 License: GNU GPL v3 http://www.gnu.org/licenses/gpl-3.0.html
 //
 // See "Neo7Segment.h" for purpose, syntax, version history, links, and more.
@@ -10,35 +11,7 @@
 #include <Adafruit_NeoPixel.h>
 
 //#define DEBUG
-#define USEDP
-#ifdef USEDP
-	#define NUM_PIXELS_PER_BOARD 29
-#else
-	#define NUM_PIXELS_PER_BOARD 28
-#endif
 
-// Array of pixels per segment, 7 segments with 4 pixels each
-byte segmentsPixels[8][4] 	{ { 0, 1, 2, 3 }, 
-                              { 4, 5, 6, 7 }, 
-                              { 8, 9, 10, 11 }, 
-                              { 12, 13, 14, 15 }, 
-                              { 16, 17, 18, 19 }, 
-                              {20, 21, 22, 23 }, 
-                              {24, 25, 26, 27 },
-							  { 28 }
-						  	};
-
-// Array of pixel positions in X,Y format for mapping colours in X,Y space
-byte pixelsXY[29][2]		{ { 1,0 }, { 2,0 }, { 3,0 }, { 4,0 },
-	                          { 5,1 }, { 5,2 }, { 5,3 }, { 5,4 },
-	                          { 5,6 }, { 5,7 }, { 5,8 }, { 5,9 },
-	                          { 4,10 }, { 3,10 }, { 2,10 }, { 1,10 },
-	                          { 0,9 }, { 0,8 }, { 0,7 },  { 0,6 },
-	                          { 0,4 }, { 0,3 }, { 0,2 }, { 0,1 },
-	                          { 1,5 }, { 2,5 }, { 3,5 }, { 4,5 },
-							  { 6,10 }
-						  	};
-					  
 // Array of segment based rainbow colour values
 uint32_t segmentRainbow[7][3] {
                               { 255,0,0 },
@@ -50,78 +23,85 @@ uint32_t segmentRainbow[7][3] {
                               { 255,30,237 }
                             };
 
-// Available characters a 7 Segment display can show					  
-const byte ARRAY_SIZE = 32;
+// Available characters a 7 Segment display can show
+const byte ARRAY_SIZE = 34;
+
 
 byte available_codes[ ARRAY_SIZE ][ 2 ] {
-							{ '0', 0b00111111  }, 
-							{ '1', 0b00000110 },
-							{ '2', 0b01011011 },
-							{ '3', 0b01001111 },
-							{ '4', 0b01100110 },
-							{ '5', 0b01101101 },
-							{ '6', 0b01111100 },
-							{ '7', 0b00000111 },
-							{ '8', 0b01111111 },
-							{ '9', 0b01100111 },
-							{ 'a', 0b01110111 },
-							{ 'b', 0b01111100 },
-							{ 'c', 0b00111001 },
-							{ 'd', 0b01011110 },
-							{ 'e', 0b01111001 },
-							{ 'f', 0b01110001 },
-							{ 'g', 0b01100111 },
-							{ 'h', 0b01110110 },
-							{ 'i', 0b00110000 },
-							{ 'j', 0b00011110 },
-							{ 'l', 0b00111000 },
-							{ 'n', 0b01010100 },
-							{ 'o', 0b01011100 },
-							{ 'p', 0b01110011 },
-							{ 'q', 0b01100111 },
-							{ 'r', 0b01010000 },
-							{ 's', 0b01101101 },
-							{ 'u', 0b00111110 },
-							{ 'x', 0b01110110 },
-							{ 'y', 0b01101110 },
-							{ '-', 0b01000000 },
-							{ ' ', 0b00000000 }
+							//   pgfedcba
+						  { '0', 0b00111111 },
+						  { '1', 0b00000110 },
+						  { '2', 0b01011011 },
+						  { '3', 0b01001111 },
+						  { '4', 0b01100110 },
+						  { '5', 0b01101101 },
+						  { '6', 0b01111101 },
+						  { '7', 0b00000111 },
+						  { '8', 0b01111111 },
+						  { '9', 0b01101111 },
+						  { 'a', 0b01110111 },
+						  { 'b', 0b01111100 },
+						  { 'c', 0b01011000 },
+						  { 'd', 0b01011110 },
+						  { 'e', 0b01111001 },
+						  { 'f', 0b01110001 },
+						  { 'g', 0b01100111 },
+						  { 'h', 0b01110110 },
+						  { 'i', 0b00010000 },
+						  { 'j', 0b00011110 },
+						  { 'l', 0b00110000 },
+						  { 'n', 0b01010100 },
+						  { 'o', 0b01011100 },
+						  { 'p', 0b01110011 },
+						  { 'q', 0b01100111 },
+						  { 'r', 0b01010000 },
+						  { 's', 0b01101101 },
+						  { 't', 0b01111000 },
+						  { 'u', 0b00011100 },
+						  { 'x', 0b01110110 },
+						  { 'y', 0b01101110 },
+						  { 'z', 0b01011011 },
+						  { '-', 0b01000000 },
+						  { ' ', 0b00000000 }
 						};
 
 byte available_codes_upper[ ARRAY_SIZE ][ 2 ] {
-							{ '0', 0b00111111 }, 
-							{ '1', 0b00000110 },
-							{ '2', 0b01011011 },
-							{ '3', 0b01001111 },
-							{ '4', 0b01100110 },
-							{ '5', 0b01101101 },
-							{ '6', 0b01111100 },
-							{ '7', 0b00000111 },
-							{ '8', 0b01111111 },
-							{ '9', 0b01100111 },
-							{ 'a', 0b01110111 },
-							{ 'b', 0b01111111 },
-							{ 'c', 0b00111001 },
-							{ 'd', 0b00111111 },
-							{ 'e', 0b01111001 },
-							{ 'f', 0b01110001 },
-							{ 'g', 0b01100111 },
-							{ 'h', 0b01110110 },
-							{ 'i', 0b00110000 },
-							{ 'j', 0b00011110 },
-							{ 'l', 0b00111000 },
-							{ 'n', 0b00110111 },
-							{ 'o', 0b00111111 },
-							{ 'p', 0b01110011 },
-							{ 'q', 0b01100111 },
-							{ 'r', 0b00110001 },
-							{ 's', 0b01101101 },
-							{ 'u', 0b00111110 },
-							{ 'x', 0b01110110 },
-							{ 'y', 0b01101110 },
-							{ '-', 0b01000000 },
-							{ ' ', 0b00000000 }
-						};					
+							//   pgfedcba
+						  { '0', 0b00111111 },
+						  { '1', 0b00000110 },
+						  { '2', 0b01011011 },
+						  { '3', 0b01001111 },
+						  { '4', 0b01100110 },
+						  { '5', 0b01101101 },
+						  { '6', 0b01111101 },
+						  { '7', 0b00000111 },
+						  { '8', 0b01111111 },
+						  { '9', 0b01101111 },
+						  { 'a', 0b01110111 },
+						  { 'b', 0b01111111 },
+						  { 'c', 0b00111001 },
+						  { 'd', 0b00111111 },
+						  { 'e', 0b01111001 },
+						  { 'f', 0b01110001 },
+						  { 'g', 0b01100111 },
+						  { 'h', 0b01110110 },
+						  { 'i', 0b00110000 },
+						  { 'j', 0b00011110 },
+						  { 'l', 0b00111000 },
+						  { 'n', 0b00110111 },
+						  { 'o', 0b00111111 },
+						  { 'p', 0b01110011 },
+						  { 'q', 0b01100111 },
+						  { 'r', 0b00110001 },
+						  { 's', 0b01101101 },
+						  { 't', 0b01111000 },
+						  { 'u', 0b00111110 },
+						  { 'x', 0b01110110 },
+						  { 'y', 0b01101110 },
+						  { 'z', 0b01011011 },
+						  { '-', 0b01000000 },
+						  { ' ', 0b00000000 }
+						};
 
 byte spinAnimAll[6] 	{
 							0b00000001,
@@ -158,9 +138,19 @@ byte AnimEdgeRight[4] 	{
 							0b00000100,
 							0b00001000
 						};
-													
-Neo7Segment::Neo7Segment( uint8_t displayCount, uint8_t dPin )
+
+Neo7Segment::Neo7Segment( uint8_t displayCount, uint8_t dPixels, uint8_t dpPixels, uint8_t dPin )
 {
+	//Count number of pixels per decimal point (Between 0 and number of segment pixels)
+	dispPixelDp = constrain(dpPixels, 0, constrain(dPixels, 1, PIXELS_PER_SEGMENT_MAX));
+
+	//Count number of pixels per digit board (Between 1 and maximum pixels)
+	NUM_PIXELS_PER_BOARD = ( constrain( dPixels, 1, PIXELS_PER_SEGMENT_MAX )*7) + dispPixelDp;
+
+	//Detect that decimal poiunt is used or not
+	dispUseDP = dpPixels>0 ? true : false;
+
+	dispPixelSegment = dPixels;
 	dispCount = displayCount;
 	dispPin = dPin;
 	pixels = Adafruit_NeoPixel ();
@@ -168,6 +158,66 @@ Neo7Segment::Neo7Segment( uint8_t displayCount, uint8_t dPin )
   	pixels.updateLength( dispCount * NUM_PIXELS_PER_BOARD );
   	pixels.setPin(dispPin);
 	isReady = false;
+}
+
+void Neo7Segment::buildSegmentsPixels()
+{
+	uint8_t segPixels = dispPixelSegment;
+	uint8_t dpPixels = dispPixelDp;
+
+	for ( int i = 0; i < 7; i++ )
+	{
+		for ( int j = 0; j < segPixels; j++ )
+			segmentsPixels[ i ][ j ] = ( i * segPixels ) + j;
+	}
+
+	for ( int j = 0; j < dpPixels; j++ )
+		segmentsPixels[ 7 ][ j ] = ( segPixels * 7) + j;
+}
+
+void Neo7Segment::buildPixelsXY()
+{
+	uint8_t segPixels = dispPixelSegment;
+	uint8_t dpPixels = dispPixelDp;
+	int i = 0;
+
+	for ( i = 0; i < segPixels; i++ )
+	{
+		//A Segment
+		pixelsXY[ i + ( 0*segPixels ) ][ 0 ] = i + 1;
+		pixelsXY[ i + ( 0*segPixels ) ][ 1 ] = 0;
+
+		//B Segment
+		pixelsXY[ i + ( 1*segPixels ) ][ 0 ] = segPixels + 1;
+		pixelsXY[ i + ( 1*segPixels ) ][ 1 ] = i + 1;
+
+		//C Segment
+		pixelsXY[ i + ( 2*segPixels ) ][ 0 ] = segPixels + 1;
+		pixelsXY[ i + ( 2*segPixels ) ][ 1 ] = segPixels + i + 2;
+
+		//D Segment
+		pixelsXY[ i + ( 3*segPixels ) ][ 0 ] = segPixels - i;
+		pixelsXY[ i + ( 3*segPixels ) ][ 1 ] = ( segPixels * 2 ) + 2;
+
+		//E Segment
+		pixelsXY[ i + ( 4*segPixels ) ][ 0 ] = 0;
+		pixelsXY[ i + ( 4*segPixels ) ][ 1 ] = ( ( segPixels * 2 ) + 1 ) - i;
+
+		//F Segment
+		pixelsXY[ i + ( 5*segPixels ) ][ 0 ] = 0;
+		pixelsXY[ i + ( 5*segPixels ) ][ 1 ] = segPixels - i;
+
+		//G Segment
+		pixelsXY[ i + ( 6*segPixels ) ][ 0 ] = i + 1;
+		pixelsXY[ i + ( 6*segPixels ) ][ 1 ] = segPixels + 1;
+	}
+
+	for (i = 0; i < dpPixels; i++)
+	{
+		//DP Segment
+		pixelsXY[ i + ( 7*segPixels ) ][ 0 ] = segPixels + 2;
+		pixelsXY[ i + ( 7*segPixels ) ][ 1 ] = ( segPixels * 2 ) + 2;
+	}
 }
 
 Neo7Segment::~Neo7Segment()
@@ -182,10 +232,15 @@ bool Neo7Segment::IsReady()
 
 void Neo7Segment::Begin( uint8_t brightness )
 {
-
 	pixels.begin(); // This initializes the NeoPixel library.
 	pixels.show();
 	pixels.setBrightness( brightness );
+
+	#ifdef DEBUG
+		Serial.print("Brightness: ");
+		Serial.println(brightness);
+		Serial.println("Ready!");
+	#endif
 
 	cachedString = "";
 	cachedBytes = (byte *) malloc(dispCount * sizeof(byte));
@@ -194,10 +249,13 @@ void Neo7Segment::Begin( uint8_t brightness )
 		cachedBytes[i] = 0;
 
 	#ifdef DEBUG
-		Serial.print("Brightness: ");
-		Serial.println(brightness);
-		Serial.println("Ready!");
+		Serial.print("Initialize: ");
+		Serial.print(dispPixelSegment);
+		Serial.println(" pixels per segment...");
 	#endif
+
+	buildSegmentsPixels();
+	buildPixelsXY();
 
 	//Digits are initialised and ready
 	isReady = true;
@@ -233,7 +291,6 @@ uint32_t Neo7Segment::Color(uint8_t r, uint8_t g, uint8_t b)
 {
   return ((uint32_t)r << 16) | ((uint32_t)g <<  8) | b;
 }
-
 
 void Neo7Segment::CheckToCacheBytes( String str )
 {
@@ -288,6 +345,9 @@ void Neo7Segment::DisplayTextVerticalRainbow( String text, uint32_t colorA, uint
 
 	uint32_t color;
 	
+	int digitHeight = 2 * dispPixelSegment + 3;
+	float digitHeightFloat = 1.0 / float( digitHeight );
+
 	// Grab the byte (bits) for the segmens for the character passed in
 	for ( int s = 0; s < lengthOfLoop; s++ )
 	{
@@ -299,14 +359,14 @@ void Neo7Segment::DisplayTextVerticalRainbow( String text, uint32_t colorA, uint
 			for( int segment = 0; segment < 7; segment++ )
 			{
 				bool on = ( bitRead( code, segment) == 1 );
-				for ( int p = 0; p < 4; p++ )
+				for ( int p = 0; p < dispPixelSegment; p++ )
 				{
 					// we want the Y position (row) so we can use that as the colour index 
 					int y = pixelsXY[ pixelIndex ][1];
 
-					uint8_t red = ((Red(colorA) * (10 - y)) + (Red(colorB) * y)) * 0.1;
-					uint8_t green = ((Green(colorA) * (10 - y)) + (Green(colorB) * y)) * 0.1;
-					uint8_t blue = ((Blue(colorA) * (10 - y)) + (Blue(colorB) * y)) * 0.1;
+					uint8_t red = ((Red(colorA) * (digitHeight - y)) + (Red(colorB) * y)) * digitHeightFloat;
+					uint8_t green = ((Green(colorA) * (digitHeight - y)) + (Green(colorB) * y)) * digitHeightFloat;
+					uint8_t blue = ((Blue(colorA) * (digitHeight - y)) + (Blue(colorB) * y)) * digitHeightFloat;
 
 					color = Color(red, green, blue );
 				
@@ -315,12 +375,12 @@ void Neo7Segment::DisplayTextVerticalRainbow( String text, uint32_t colorA, uint
 				}
 			}
 
-			#ifdef USEDP
-
+			if ( dispUseDP )
+			{
 				bool on = ( bitRead( code, 7) == 1 );
-				pixels.setPixelColor( segmentsPixels[ 7 ][ 0 ], on ? color : Color(0,0,0));
-
-			#endif
+				for ( int p = 0; p < dispPixelDp; p++)
+					pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
+			}
 		}
 	}
 		
@@ -335,7 +395,7 @@ void Neo7Segment::DisplayTextHorizontalRainbow( String text, uint32_t colorA, ui
 	
 	CheckToCacheBytes( text );
 
-	int numPixelsPerColumn = 6;
+	int numPixelsPerColumn = dispPixelSegment + 2;
 	int numColumns = dispCount * numPixelsPerColumn;
 
 	uint32_t color;
@@ -343,7 +403,7 @@ void Neo7Segment::DisplayTextHorizontalRainbow( String text, uint32_t colorA, ui
 	// Clamp the length, so text longer than the display count is ignored
 	int lengthOfLoop = min( dispCount, (uint8_t)text.length() );
 	
-	// Grab the byte (bits) for the segmens for the character passed in
+	// Grab the byte (bits) for the segments for the character passed in
 	for ( int s = 0; s < lengthOfLoop; s++ )
 	{
 		byte code = cachedBytes[s];
@@ -354,7 +414,7 @@ void Neo7Segment::DisplayTextHorizontalRainbow( String text, uint32_t colorA, ui
 			for( int segment = 0; segment < 7; segment++ )
 			{
 				bool on = ( bitRead( code, segment) == 1 );
-				for ( int p = 0; p < 4; p++ )
+				for ( int p = 0; p < dispPixelSegment; p++ )
 				{
 					// we want the Y position (row) so we can use that as the colour index 
 					int x = pixelsXY[ pixelIndex ][0] + ( numPixelsPerColumn * s );
@@ -370,12 +430,12 @@ void Neo7Segment::DisplayTextHorizontalRainbow( String text, uint32_t colorA, ui
 				}
 			}
 
-			#ifdef USEDP
-
+			if ( dispUseDP )
+			{
 				bool on = ( bitRead( code, 7) == 1 );
-				pixels.setPixelColor( segmentsPixels[ 7 ][ 0 ], on ? color : Color(0,0,0));
-
-			#endif
+				for ( int p = 0; p < dispPixelDp; p++ )
+					pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
+			}
 		}
 	}
 		
@@ -393,7 +453,7 @@ void Neo7Segment::DisplayTextMarquee( String text, uint8_t index, uint32_t color
 	// Clamp the length, so text longer than the display count is ignored
 	int lengthOfLoop = min( dispCount, (uint8_t)text.length() );
 
-	// Grab the byte (bits) for the segmens for the character passed in
+	// Grab the byte (bits) for the segments for the character passed in
 	for ( int s = 0; s < lengthOfLoop; s++ )
 	{
 		byte code = cachedBytes[s];
@@ -402,25 +462,35 @@ void Neo7Segment::DisplayTextMarquee( String text, uint8_t index, uint32_t color
 		{
 			for( int segment = 0; segment < 7; segment++ )
 			{
-				for ( int p = 0; p < 4; p++ )
+				for ( int p = 0; p < dispPixelSegment; p++ )
 				{
 					bool on = ( bitRead( code, segment) == 1 );
-									
-					if ( index == 0 && ( p == 1 || p == 3 ) )
+					bool evenPixel = ( (p % 2) == 0 ) ? true : false;
+
+					if ( index == 0 && !evenPixel )
 						on = false;
-					else if ( index == 1 && ( p == 0 || p == 2 ) )
+					else if ( index == 1 && evenPixel )
 						on = false;
 
 					pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
 				}
 			}
 
-			#ifdef USEDP
-
+			if ( dispUseDP )
+			{
 				bool on = ( bitRead( code, 7) == 1 );
-				pixels.setPixelColor( segmentsPixels[ 7 ][ 0 ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0));
+				for ( int p = 0; p < dispPixelDp; p++ )
+				{
+					bool evenPixel = ( (p % 2) == 0 ) ? true : false;
 
-			#endif
+					if ( index == 0 && !evenPixel && dispPixelDp > 1 )
+						on = false;
+					else if ( index == 1 && evenPixel && dispPixelDp > 1 )
+						on = false;
+
+					pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
+				}
+			}
 		}
 	}
 	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
@@ -437,7 +507,7 @@ void Neo7Segment::DisplayTextChaser( String text, uint8_t index, uint32_t color 
 	// Clamp the length, so text longer than the display count is ignored
 	int lengthOfLoop = min( dispCount, (uint8_t)text.length() );
 
-	// Grab the byte (bits) for the segmens for the character passed in
+	// Grab the byte (bits) for the segments for the character passed in
 	for ( int s = 0; s < lengthOfLoop; s++ )
 	{
 		byte code = cachedBytes[s];
@@ -446,7 +516,7 @@ void Neo7Segment::DisplayTextChaser( String text, uint8_t index, uint32_t color 
 		{
 			for( int segment = 0; segment < 7; segment++ )
 			{
-				for ( int p = 0; p < 4; p++ )
+				for ( int p = 0; p < dispPixelSegment; p++ )
 				{
 					bool on = ( bitRead( code, segment) == 1 );
 									
@@ -457,12 +527,12 @@ void Neo7Segment::DisplayTextChaser( String text, uint8_t index, uint32_t color 
 				}
 			}
 
-			#ifdef USEDP
-
+			if ( dispUseDP )
+			{
 				bool on = ( bitRead( code, 7) == 1 );
-				pixels.setPixelColor( segmentsPixels[ 7 ][ 0 ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0));
-
-			#endif
+				for ( int p = 0; p < dispPixelDp; p++ )
+					pixels.setPixelColor(segmentsPixels[ 7 ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
+			}
 		}
 	}
 	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
@@ -481,7 +551,7 @@ void Neo7Segment::DisplayTextColorCycle( String text, uint8_t index )
 
 	uint32_t color;
 	
-	// Grab the byte (bits) for the segmens for the character passed in
+	// Grab the byte (bits) for the segments for the character passed in
 	for ( int s = 0; s < lengthOfLoop; s++ )
 	{
 		byte code = cachedBytes[s];
@@ -493,20 +563,20 @@ void Neo7Segment::DisplayTextColorCycle( String text, uint8_t index )
 			for( int segment = 0; segment < 7; segment++ )
 			{
 				bool on = ( bitRead( code, segment) == 1 );
-				for ( int p = 0; p < 4; p++ )
+				for ( int p = 0; p < dispPixelSegment; p++ )
 				{
 					color = Wheel( colorStart & 255 );
 					pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
-					colorStart+=(255/28);	
+					colorStart+=(255/dispPixelSegment*7);
 				}
 			}
 
-			#ifdef USEDP
-
+			if ( dispUseDP )
+			{
 				bool on = ( bitRead( code, 7) == 1 );
-				pixels.setPixelColor( segmentsPixels[ 7 ][ 0 ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0));
-
-			#endif
+				for ( int p = 0; p < dispPixelDp; p++ )
+					pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
+			}
 		}
 	}
 
@@ -525,7 +595,7 @@ void Neo7Segment::DisplayTextColor( String text, uint32_t color )
 	// Clamp the length, so text longer than the display count is ignored
 	int lengthOfLoop = min( dispCount, (uint8_t)text.length() );
 
-	// Grab the byte (bits) for the segmens for the character passed in
+	// Grab the byte (bits) for the segments for the character passed in
 	for ( int s = 0; s < lengthOfLoop; s++ )
 	{
 		byte code = cachedBytes[s];
@@ -535,16 +605,52 @@ void Neo7Segment::DisplayTextColor( String text, uint32_t color )
 			for( int segment = 0; segment < 7; segment++ )
 			{
 				bool on = ( bitRead( code, segment) == 1 );
-				for ( int p = 0; p < 4; p++ )
+				for ( int p = 0; p < dispPixelSegment; p++ )
 					pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
 			}
 
-			#ifdef USEDP
-
+			if ( dispUseDP )
+			{
 				bool on = ( bitRead( code, 7) == 1 );
-				pixels.setPixelColor( segmentsPixels[ 7 ][ 0 ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0));
+				for ( int p = 0; p < dispPixelDp; p++ )
+					pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
+			}
+		}
+	}
+	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
+	pixels.show();
+}
 
-			#endif
+void Neo7Segment::DisplayTextDigitColor( String text, uint32_t color[] )
+{
+	if ( !isReady )
+		return;
+
+	CheckToCacheBytes( text );
+
+	// Clamp the length, so text longer than the display count is ignored
+	int lengthOfLoop = min( dispCount, (uint8_t)text.length() );
+
+	// Grab the byte (bits) for the segments for the character passed in
+	for ( int s = 0; s < lengthOfLoop; s++ )
+	{
+		byte code = cachedBytes[s];
+
+		if(code > -1)
+		{
+			for( int segment = 0; segment < 7; segment++ )
+			{
+				bool on = ( bitRead( code, segment) == 1 );
+				for ( int p = 0; p < dispPixelSegment; p++ )
+					pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color[s] : Color(0,0,0) );
+			}
+
+			if ( dispUseDP )
+			{
+				bool on = ( bitRead( code, 7) == 1 );
+				for ( int p = 0; p < dispPixelDp; p++ )
+					pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color[s] : Color(0,0,0) );
+			}
 		}
 	}
 	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
@@ -574,7 +680,7 @@ void Neo7Segment::DisplayTime( uint8_t hours, uint8_t mins, uint8_t secs, uint32
 	// Clamp the length, so text longer than the display count is ignored
 	int lengthOfLoop = min( dispCount, (uint8_t)text.length() );
 
-	// Grab the byte (bits) for the segmens for the character passed in
+	// Grab the byte (bits) for the segments for the character passed in
 	for ( int s = 0; s < lengthOfLoop; s++ )
 	{
 		byte code = cachedBytes[s];
@@ -584,26 +690,44 @@ void Neo7Segment::DisplayTime( uint8_t hours, uint8_t mins, uint8_t secs, uint32
 			uint32_t cachedColor = colorH;
 
 			// displaying mins, so work out new color
-			if ( s >= dispCount - 2 )
-			{
+			if ( s >= text.length() - 2 )
 				cachedColor = ( secs % 2 == 0 ) ? colorM2 : colorM;
-			}
 
 			for( int segment = 0; segment < 7; segment++ )
 			{
 				bool on = ( bitRead( code, segment) == 1 );
-				for ( int p = 0; p < 4; p++ )
+				for ( int p = 0; p < dispPixelSegment; p++ )
 					pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? cachedColor : Color(0,0,0) );
 			}
 
-			#ifdef USEDP
-
+			if (dispUseDP)
+			{
 				bool on = ( bitRead( code, 7) == 1 );
-				pixels.setPixelColor( segmentsPixels[ 7 ][ 0 ] + ( s * NUM_PIXELS_PER_BOARD ), on ? cachedColor : Color(0,0,0));
-
-			#endif
+				for ( int p = 0; p < dispPixelDp; p++ )
+					pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? cachedColor : Color(0,0,0) );
+			}
 		}
 	}
+
+	// Blank extra digits
+	if ( text.length() < dispCount )
+	{
+		for ( int s = lengthOfLoop; s < dispCount; s++ )
+		{
+			for( int segment = 0; segment < 7; segment++ )
+			{
+				for ( int p = 0; p < dispPixelSegment; p++ )
+				pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), Color(0,0,0) );
+			}
+
+			if (dispUseDP)
+			{
+				for ( int p = 0; p < dispPixelDp; p++ )
+					pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), Color(0,0,0) );
+			}
+		}
+	}
+
 	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
 	pixels.show();
 }
@@ -621,27 +745,25 @@ void Neo7Segment::DisplayKnightRider( uint8_t index, uint32_t color )
 
 	uint32_t colorFade = Color( r, g, b );
 
-	int pixelIndex = ( index % (dispCount * 8 ) );
-	if ( pixelIndex > (dispCount * 4) - 1 )
+	int pixelIndex = ( index % (dispCount * (2*dispPixelSegment) ) );
+	if ( pixelIndex > (dispCount * dispPixelSegment) - 1 )
 	{
-		pixelIndex = ( dispCount * 8 ) - (pixelIndex + 1 );
+		pixelIndex = ( dispCount * ( 2*dispPixelSegment ) ) - (pixelIndex + 1 );
 		isForward = false;
 	}
 	
-	// Grab the byte (bits) for the segmens for the character passed in
+	// Grab the byte (bits) for the segments for the character passed in
 	for ( int s = 0; s < dispCount; s++ )
 	{
 		for( int segment = 0; segment < 7; segment++ )
 		{
-			for ( int p = 0; p < 4; p++ )
+			for ( int p = 0; p < dispPixelSegment; p++ )
 			{
 				if ( segment != 6 )
-				{
 					pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), Color(0,0,0) );
-				}
 				else
 				{
-					uint8_t currentIndex = ( s * 4 + p );
+					uint8_t currentIndex = ( s * dispPixelSegment + p );
 					if ( currentIndex == pixelIndex )
 						pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), color );
 					else if ( isForward && currentIndex == pixelIndex - 1 )
@@ -654,11 +776,11 @@ void Neo7Segment::DisplayKnightRider( uint8_t index, uint32_t color )
 			}		
 		}
 
-		#ifdef USEDP
-
-			pixels.setPixelColor( segmentsPixels[ 7 ][ 0 ] + ( s * NUM_PIXELS_PER_BOARD ), Color(0,0,0) );
-
-		#endif
+		if ( dispUseDP )
+		{
+			for ( int p = 0; p < dispPixelDp; p++ )
+				pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), Color(0,0,0) );
+		}
 	}
 	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
 	pixels.show();
@@ -715,21 +837,21 @@ void Neo7Segment::DisplayBorderAnimation( uint8_t index, uint32_t color )
 			if ( s == curentDisplay )
 			{
 				bool on = ( bitRead( code, segment) == 1 );
-				for ( int p = 0; p < 4; p++ )
+				for ( int p = 0; p < dispPixelSegment; p++ )
 					pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
 			}
 			else
 			{
-				for ( int p = 0; p < 4; p++ )
+				for ( int p = 0; p < dispPixelSegment; p++ )
 					pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), Color(0,0,0) );
 			}
 		}
 
-		#ifdef USEDP
-
-			pixels.setPixelColor( segmentsPixels[ 7 ][ 0 ] + ( s * NUM_PIXELS_PER_BOARD ), Color(0,0,0) );
-
-		#endif
+		if ( dispUseDP )
+		{
+			for ( int p = 0; p < dispPixelDp; p++ )
+				pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), Color(0,0,0) );
+		}
 	}
 
 	// we have finished setting all of the colors on each segment for this Neo7Segment, so lets turn on the pixels
@@ -772,8 +894,34 @@ void Neo7Segment::SetDigit( uint8_t digit, String text, uint32_t color )
 {
 	if ( !isReady )
 		return;
-		
+
+	if ( digit < 0 || digit > dispCount )
+		return;
+
+	CheckToCacheBytes( text );
+
+	byte code = cachedBytes[0]; //No matter the length of string received, only first character with it's point will be displayed on requested digit
+
+	if(code > -1)
+	{
+		for( int segment = 0; segment < 7; segment++ )
+		{
+			bool on = ( bitRead( code, segment) == 1 );
+			for ( int p = 0; p < dispPixelSegment; p++ )
+				pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( digit * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
+		}
+
+		if ( dispUseDP )
+		{
+			bool on = ( bitRead( code, 7) == 1 );
+			for ( int p = 0; p < dispPixelDp; p++ )
+				pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( digit * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
+		}
+	}
+
+	pixels.show();
 }
+
 void Neo7Segment::SetDigitSegments( uint8_t digit, byte bits, uint32_t color )
 {
 	if ( !isReady )
@@ -785,16 +933,16 @@ void Neo7Segment::SetDigitSegments( uint8_t digit, byte bits, uint32_t color )
 	for( int segment = 0; segment < 7; segment++ )
 	{
 		bool on = ( bitRead( bits, segment ) == 1 );
-		for ( int p = 0; p < 4; p++ )
+		for ( int p = 0; p < dispPixelSegment; p++ )
 			pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( digit * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );		
 	}
 
-	#ifdef USEDP
-
-		bool on = ( bitRead( bits, 7 ) == 1 );
-		pixels.setPixelColor( segmentsPixels[ 7 ][ 0 ] + ( digit * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
-
-	#endif
+	if ( dispUseDP )
+	{
+		bool on = ( bitRead( bits, 7) == 1 );
+		for ( int p = 0; p < dispPixelDp; p++ )
+			pixels.setPixelColor( segmentsPixels[ 7 ][ p ] + ( digit * NUM_PIXELS_PER_BOARD ), on ? color : Color(0,0,0) );
+	}
 
 	pixels.show();
 }
@@ -839,8 +987,6 @@ String Neo7Segment::PadTimeData( int8_t data )
   return String(data);
 }
 
-
-
 // Input a value 0 to 255 to get a color value.
 // The colours are a transition r - g - b - back to r.
 uint32_t Neo7Segment::Wheel(byte WheelPos )
@@ -868,7 +1014,6 @@ uint8_t Neo7Segment::Green( uint32_t col )
 {
 	return col >> 8;
 }
-
 
 uint8_t Neo7Segment::Blue( uint32_t col )
 {

--- a/src/Neo7Segment.cpp
+++ b/src/Neo7Segment.cpp
@@ -152,7 +152,7 @@ Neo7Segment::Neo7Segment( uint8_t displayCount, uint8_t dPixels, uint8_t dpPixel
 	//Count number of pixels per digit board (Between 1 and maximum pixels)
 	NUM_PIXELS_PER_BOARD = ( constrain( dPixels, 1, PIXELS_PER_SEGMENT_MAX )*7) + dispPixelDp;
 
-	//Detect that decimal poiunt is used or not
+	//Detect that decimal point is used or not
 	dispUseDP = dispPixelDp>0 ? true : false;
 
 	dispPixelSegment = dPixels;
@@ -177,7 +177,7 @@ Neo7Segment::Neo7Segment( uint8_t displayCount, uint8_t dPin )
 	//Count number of pixels per digit board (Between 1 and maximum pixels)
 	NUM_PIXELS_PER_BOARD = 28 + dispPixelDp;
 
-	//Detect that decimal poiunt is used or not
+	//Detect that decimal point is used or not
 	dispUseDP = dispPixelDp>0 ? true : false;
 
 	dispPixelSegment = 4;

--- a/src/Neo7Segment.cpp
+++ b/src/Neo7Segment.cpp
@@ -747,7 +747,7 @@ void Neo7Segment::DisplayTime( uint8_t hours, uint8_t mins, uint8_t secs, uint32
 			for( int segment = 0; segment < 7; segment++ )
 			{
 				for ( int p = 0; p < dispPixelSegment; p++ )
-				pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), Color(0,0,0) );
+					pixels.setPixelColor( segmentsPixels[ segment ][ p ] + ( s * NUM_PIXELS_PER_BOARD ), Color(0,0,0) );
 			}
 
 			if (dispUseDP)

--- a/src/Neo7Segment.h
+++ b/src/Neo7Segment.h
@@ -62,6 +62,7 @@
 class Neo7Segment
 {
 	public:
+		Neo7Segment( uint8_t displayCount, uint8_t dPin );
 		Neo7Segment( uint8_t displayCount, uint8_t dPixels, uint8_t dpPixels, uint8_t dPin );
 		~Neo7Segment();
 		

--- a/src/Neo7Segment.h
+++ b/src/Neo7Segment.h
@@ -1,9 +1,11 @@
 // ---------------------------------------------------------------------------
-// Neo7Segment Library - v1.0.1 - 25/04/2018
+// Neo7Segment Library - v2.0.3 - 06/01/2019
 //
 // AUTHOR/LICENSE:
 // Created by Seon Rozenblum - seon@unexpectedmaker.com
 // Copyright 2016 License: GNU GPL v3 http://www.gnu.org/licenses/gpl-3.0.html
+//
+// Modified by SupremeSports 06/01/2019
 //
 // LINKS:
 // Project home: XXX <--
@@ -15,18 +17,26 @@
 //
 // PURPOSE:
 // Seven Segment Library for the Neo7Segment display boards, or for use with strips of NeoPixels arranged as 7 Segment displays
+// This new update allows users to customize the number of pixels per segment or decimal point. It also allows many different
+// 	displays to use separated classes, so displays can us different pixel numbers and digit numbers.
 //
 // SYNTAX:
-//   Neo7Segment( digits, pin ) - Initialise the array of displays
+//   Neo7Segment( digits, pixels, decimal, pin ) - Initialise the array of displays
 //     Parameters:
 //		* digits		- The number of digits you will be displaying on
+//		* pixels		- The number of pixels per segment
+//		* decimal		- The number of pixels per decimal point
 //		* pin			- Pin speaker is wired to (other wire to ground, be sure to add an inline 100 ohm resistor).
 //
 // HISTORY:
 
 //
-// 25/04/2018 v1.0.1 - Fixed bug due to change in Adafruit Neopixel library initialisation
-// 28/01/2018 v1.0 - Initial release.
+// 02/01/2019 v2.0.3  - Modified to allow the class to work with many different display sizes. By SupremeSports
+// 28/12/2018 v2.0.2  - Fixed few bugs with the variable arrays
+// 05/12/2018 v2.0.1  - Fixed decimal point definition. Custom number of pixels for decimal point. By SupremeSports
+// 05/12/2018 v2.0    - Custom number of pixel per segment. By SupremeSports
+// 25/04/2018 v1.0.1  - Fixed bug due to change in Adafruit Neopixel library initialisation
+// 28/01/2018 v1.0    - Initial release.
 //
 // ---------------------------------------------------------------------------
 
@@ -46,11 +56,13 @@
 	  #include <avr/power.h>
 	#endif
 	
+	#define PIXELS_PER_SEGMENT_MAX 10
+	#define PIXELS_PER_DP_MAX 10
 
 class Neo7Segment
 {
 	public:
-		Neo7Segment( uint8_t displayCount, uint8_t dPin );
+		Neo7Segment( uint8_t displayCount, uint8_t dPixels, uint8_t dpPixels, uint8_t dPin );
 		~Neo7Segment();
 		
 		void Begin( uint8_t brightness );
@@ -60,6 +72,7 @@ class Neo7Segment
 		void DisplayTextHorizontalRainbow( String text, uint32_t colorA, uint32_t colorB );
 		void DisplayTextColor( String text, uint32_t color );
 		void DisplayTextColorCycle( String text, uint8_t index );
+		void DisplayTextDigitColor( String text, uint32_t color[] );
 		void DisplayTextMarquee( String text, uint8_t index, uint32_t color );
 		void DisplayTextChaser( String text, uint8_t index, uint32_t color );
 		void DisplayKnightRider( uint8_t index, uint32_t color );
@@ -85,18 +98,24 @@ class Neo7Segment
 
 		bool IsReady( void );
 		
-	protected:
+		int FindIndexOfChar(String character);
+		byte FindByteForCharater( String character );
 
-		
+	protected:
+		void buildSegmentsPixels();
+		void buildPixelsXY();
+
 	private:
 		Adafruit_NeoPixel pixels;
 		uint8_t dispCount;
+		uint8_t NUM_PIXELS_PER_BOARD;
+		uint8_t dispPixelSegment;
+		uint8_t dispPixelDp;
 		uint8_t dispPin;
+		bool dispUseDP;
 		byte GetArraySize();
 		String GetCharacterAtArrayIndex( int index );
 		void SetupCharacters();
-		int FindIndexOfChar(String character);
-		byte FindByteForCharater( String character );
 		void CheckToCacheBytes( String s );
 		String PadTimeData( int8_t data );
 		uint8_t Red( uint32_t col );
@@ -107,6 +126,10 @@ class Neo7Segment
 				 bool isReady;
 		 bool isForcedUpper;
 
+		// Array of pixels per segment and pixels per decimal point
+		byte segmentsPixels[8][PIXELS_PER_SEGMENT_MAX];
 
+		// Array of pixel positions in X,Y format for mapping colours in X,Y space
+		byte pixelsXY[( PIXELS_PER_SEGMENT_MAX*7 )+PIXELS_PER_DP_MAX][2];
 };
 #endif


### PR DESCRIPTION
I reworked the neo7segment library for custom sized digits and corrected few bugs.
I really think it would be good for everyone. I spent many hours in getting this to work very good. It has been tested with 6 digits 8 pixels/segment and another display of 8 digits 4 pixels/segment. It works very good.

-Allows to determine the number of pixels per segment
-Allows to determine the number of pixels per decimal point.
-You can call the library with 0 decimal points and it serves the same purpose as removing the #define USEDP
-Also corrected few bugs in the original library that had decimal point to fail
-The segmentsPixels and pixelsXY arrays are now filled in dynamically
-Slightly modified the available_codes and available_codes_upper arrays to reflect real characters
-You can use two different displays with different size since I modified the class a little bit
-Added few functions